### PR TITLE
Improve render-assets script files

### DIFF
--- a/src/assets-renderer/gtk2/render-assets.sh
+++ b/src/assets-renderer/gtk2/render-assets.sh
@@ -28,9 +28,9 @@ do
 		echo
 		echo Rendering $ASSETS_DIR/$i.png
 		$INKSCAPE --export-id=$i \
-		          --export-id-only \
-		          --export-png=$ASSETS_DIR/$i.png $SRC_FILE &> /dev/null \
-		&& $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png 
+				  --export-id-only \
+				  --export-png=$ASSETS_DIR/$i.png $SRC_FILE &> /dev/null \
+		&& $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png
 	fi
 
 	if [ -f $ASSETS_DIR_DARK/$i.png ]; then
@@ -39,9 +39,9 @@ do
 		echo
 		echo Rendering $ASSETS_DIR_DARK/$i.png
 		$INKSCAPE --export-id=$i \
-		          --export-id-only \
-		          --export-png=$ASSETS_DIR_DARK/$i.png $SRC_FILE_DARK &> /dev/null \
-		&& $OPTIPNG -o7 --quiet $ASSETS_DIR_DARK/$i.png 
+				  --export-id-only \
+				  --export-png=$ASSETS_DIR_DARK/$i.png $SRC_FILE_DARK &> /dev/null \
+		&& $OPTIPNG -o7 --quiet $ASSETS_DIR_DARK/$i.png
 	fi
 
 	if [ -f $ASSETS_DIR_DARKEST/$i.png ]; then
@@ -50,9 +50,9 @@ do
 		echo
 		echo Rendering $ASSETS_DIR_DARKEST/$i.png
 		$INKSCAPE --export-id=$i \
-		          --export-id-only \
-		          --export-png=$ASSETS_DIR_DARKEST/$i.png $SRC_FILE_DARKEST &> /dev/null \
-		&& $OPTIPNG -o7 --quiet $ASSETS_DIR_DARKEST/$i.png 
+				  --export-id-only \
+				  --export-png=$ASSETS_DIR_DARKEST/$i.png $SRC_FILE_DARKEST &> /dev/null \
+		&& $OPTIPNG -o7 --quiet $ASSETS_DIR_DARKEST/$i.png
 	fi
 done
 
@@ -62,7 +62,6 @@ cp $ASSETS_DIR/entry-disabled-toolbar.png "$MENU_TOOLBAR_DIR"/entry-disabled-too
 
 cp $ASSETS_DIR/menubar.png "$MENU_TOOLBAR_DIR"/menubar.png
 cp $ASSETS_DIR/menubar_button.png "$MENU_TOOLBAR_DIR"/menubar_button.png
-
 
 cp $ASSETS_DIR_DARK/button.png "$MENU_TOOLBAR_DIR"/button.png
 cp $ASSETS_DIR_DARK/button-hover.png "$MENU_TOOLBAR_DIR"/button-hover.png
@@ -82,4 +81,3 @@ cp $ASSETS_DIR_DARKEST/entry-disabled-toolbar.png "$MENU_TOOLBAR_DIR"/entry-disa
 
 cp $ASSETS_DIR_DARKEST/menubar.png "$MENU_TOOLBAR_DIR"/menubar-darkest.png
 cp $ASSETS_DIR_DARKEST/menubar_button.png "$MENU_TOOLBAR_DIR"/menubar_button-darkest.png
-

--- a/src/assets-renderer/gtk2/render-assets.sh
+++ b/src/assets-renderer/gtk2/render-assets.sh
@@ -1,83 +1,56 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Required applications
 INKSCAPE=/usr/bin/inkscape
 OPTIPNG=/usr/bin/optipng
 
-SRC_FILE="$DIR"/assets.svg
-ASSETS_DIR="$DIR"/assets
+# Required directories
+[ ! -d "$DIR/menubar-toolbar" ] && mkdir "$DIR/menubar-toolbar"
 
-SRC_FILE_DARK="$DIR"/assets-dark.svg
-ASSETS_DIR_DARK="$DIR"/assets-dark
+# Template variations
+templates=( "" "-dark" "-darkest" )
 
-SRC_FILE_DARKEST="$DIR"/assets-darkest.svg
-ASSETS_DIR_DARKEST="$DIR"/assets-darkest
+index="$DIR/assets.txt"
+# For each variation
+for t in "${templates[@]}"; do
+	src="$DIR/assets${t}.svg"
+	assets="$DIR/assets${t}"
+	mkdir "$assets"
+	# The loop below generates a png file for each asset element listed in $index.
+	# These assets are extracted from .svg files located in $DIR
+	for i in $(cat "$index"); do
+		if [ ! -f "$assets/$i.png" ]; then
+			echo "Rendering $assets/$i.png"
+			$INKSCAPE --export-id="$i" \
+					  --export-id-only \
+					  --export-png="$assets/$i.png" "$src" 1> /dev/null &&
+				$OPTIPNG -o7 --quiet "$assets/$i.png" ||
+				echo "Error occurred when rendering $assets/$i.png" 1>&2
+		fi
+	done
 
-MENU_TOOLBAR_DIR="$DIR"/menubar-toolbar
+	# Duplicate some rendered files for menubar/toolbar; example
+	# entry-toolbar.png for the dark variation should be placed as
+	# menubar-toolbar/entry-toolbar-dark.png.
 
-INDEX="$DIR"/"assets.txt"
+	# @TODO Note that all menubar assets are shared between template variations.
+	# Because of this, the theme template may not use some of these files. It is
+	# a good idea to remove them.
 
-mkdir "$ASSETS_DIR" "$ASSETS_DIR_DARK" "$ASSETS_DIR_DARKEST" "$MENU_TOOLBAR_DIR"
-
-for i in $(cat $INDEX)
-do
-	if [ -f $ASSETS_DIR/$i.png ]; then
-		echo $ASSETS_DIR/$i.png exists.
-	else
-		echo
-		echo Rendering $ASSETS_DIR/$i.png
-		$INKSCAPE --export-id=$i \
-				  --export-id-only \
-				  --export-png=$ASSETS_DIR/$i.png $SRC_FILE &> /dev/null \
-		&& $OPTIPNG -o7 --quiet $ASSETS_DIR/$i.png
-	fi
-
-	if [ -f $ASSETS_DIR_DARK/$i.png ]; then
-		echo $ASSETS_DIR_DARK/$i.png exists.
-	else
-		echo
-		echo Rendering $ASSETS_DIR_DARK/$i.png
-		$INKSCAPE --export-id=$i \
-				  --export-id-only \
-				  --export-png=$ASSETS_DIR_DARK/$i.png $SRC_FILE_DARK &> /dev/null \
-		&& $OPTIPNG -o7 --quiet $ASSETS_DIR_DARK/$i.png
-	fi
-
-	if [ -f $ASSETS_DIR_DARKEST/$i.png ]; then
-		echo $ASSETS_DIR_DARKEST/$i.png exists.
-	else
-		echo
-		echo Rendering $ASSETS_DIR_DARKEST/$i.png
-		$INKSCAPE --export-id=$i \
-				  --export-id-only \
-				  --export-png=$ASSETS_DIR_DARKEST/$i.png $SRC_FILE_DARKEST &> /dev/null \
-		&& $OPTIPNG -o7 --quiet $ASSETS_DIR_DARKEST/$i.png
+	# @TODO There is no reason why this needs to be hard-coded here. Perhaps,
+	# having another 'index' file for these renames would be beneficial.
+	cp "$assets/entry-toolbar.png" "$DIR/menubar-toolbar/entry-toolbar${t}.png"
+	cp "$assets/entry-active-toolbar.png" "$DIR/menubar-toolbar/entry-active-toolbar${t}.png"
+	cp "$assets/entry-disabled-toolbar.png" "$DIR/menubar-toolbar/entry-disabled-toolbar${t}.png"
+	cp "$assets/menubar.png" "$DIR/menubar-toolbar/menubar${t}.png"
+	cp "$assets/menubar_button.png" "$DIR/menubar-toolbar/menubar_button${t}.png"
+	# Special cases
+	if [ "$t" = "-dark" ]; then
+		cp "$assets/button.png" "$DIR/menubar-toolbar/button.png"
+		cp "$assets/button-hover.png" "$DIR/menubar-toolbar/button-hover.png"
+		cp "$assets/button-active.png" "$DIR/menubar-toolbar/button-active.png"
+		cp "$assets/button-insensitive.png" "$DIR/menubar-toolbar/button-insensitive.png"
 	fi
 done
-
-cp $ASSETS_DIR/entry-toolbar.png "$MENU_TOOLBAR_DIR"/entry-toolbar.png
-cp $ASSETS_DIR/entry-active-toolbar.png "$MENU_TOOLBAR_DIR"/entry-active-toolbar.png
-cp $ASSETS_DIR/entry-disabled-toolbar.png "$MENU_TOOLBAR_DIR"/entry-disabled-toolbar.png
-
-cp $ASSETS_DIR/menubar.png "$MENU_TOOLBAR_DIR"/menubar.png
-cp $ASSETS_DIR/menubar_button.png "$MENU_TOOLBAR_DIR"/menubar_button.png
-
-cp $ASSETS_DIR_DARK/button.png "$MENU_TOOLBAR_DIR"/button.png
-cp $ASSETS_DIR_DARK/button-hover.png "$MENU_TOOLBAR_DIR"/button-hover.png
-cp $ASSETS_DIR_DARK/button-active.png "$MENU_TOOLBAR_DIR"/button-active.png
-cp $ASSETS_DIR_DARK/button-insensitive.png "$MENU_TOOLBAR_DIR"/button-insensitive.png
-
-cp $ASSETS_DIR_DARK/entry-toolbar.png "$MENU_TOOLBAR_DIR"/entry-toolbar-dark.png
-cp $ASSETS_DIR_DARK/entry-active-toolbar.png "$MENU_TOOLBAR_DIR"/entry-active-toolbar-dark.png
-cp $ASSETS_DIR_DARK/entry-disabled-toolbar.png "$MENU_TOOLBAR_DIR"/entry-disabled-toolbar-dark.png
-
-cp $ASSETS_DIR_DARK/menubar.png "$MENU_TOOLBAR_DIR"/menubar-dark.png
-cp $ASSETS_DIR_DARK/menubar_button.png "$MENU_TOOLBAR_DIR"/menubar_button-dark.png
-
-cp $ASSETS_DIR_DARKEST/entry-toolbar.png "$MENU_TOOLBAR_DIR"/entry-toolbar-darkest.png
-cp $ASSETS_DIR_DARKEST/entry-active-toolbar.png "$MENU_TOOLBAR_DIR"/entry-active-toolbar-darkest.png
-cp $ASSETS_DIR_DARKEST/entry-disabled-toolbar.png "$MENU_TOOLBAR_DIR"/entry-disabled-toolbar-darkest.png
-
-cp $ASSETS_DIR_DARKEST/menubar.png "$MENU_TOOLBAR_DIR"/menubar-darkest.png
-cp $ASSETS_DIR_DARKEST/menubar_button.png "$MENU_TOOLBAR_DIR"/menubar_button-darkest.png

--- a/src/assets-renderer/gtk3/render-assets.sh
+++ b/src/assets-renderer/gtk3/render-assets.sh
@@ -1,37 +1,37 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Required applications
 INKSCAPE=/usr/bin/inkscape
 OPTIPNG=/usr/bin/optipng
 
-SRC_FILE="$DIR"/assets.svg
-ASSETS_DIR="$DIR"/assets
-INDEX="$DIR"/assets.txt
+assets="$DIR/assets"
+# Required directories
+[ ! -d "$assets" ] && mkdir "$assets"
 
-mkdir "$ASSETS_DIR"
+src="$DIR/assets.svg"
+index="$DIR/assets.txt"
 
-for i in $(cat "$INDEX")
-do
-	if [ -f "$ASSETS_DIR/$i.png" ]; then
-		echo "$ASSETS_DIR/$i.png" exists.
-	else
-		echo
-		echo Rendering "$ASSETS_DIR/$i.png"
-		$INKSCAPE --export-id=$i \
+# The loop below generates two png files, with different DPI settings, for each
+# asset element listed in $index. These assets are extracted from .svg files
+# located in $DIR
+for i in $(cat "$index"); do
+	if [ ! -f "$assets/$i.png" ]; then
+		echo "Rendering $assets/$i.png"
+		$INKSCAPE --export-id="$i" \
 				  --export-id-only \
-				  --export-png="$ASSETS_DIR/$i.png" "$SRC_FILE" &> /dev/null \
-		&& $OPTIPNG -o7 --quiet "$ASSETS_DIR/$i.png"
-	fi
-	if [ -f "$ASSETS_DIR"/$i@2.png ]; then
-		echo "$ASSETS_DIR"/$i@2.png exists.
-	else
-		echo
-		echo Rendering "$ASSETS_DIR"/$i@2.png
-		$INKSCAPE --export-id=$i \
+				  --export-png="$assets/$i.png" "$src" 1> /dev/null &&
+			$OPTIPNG -o7 --quiet "$assets/$i.png" ||
+			echo "Error occurred when rendering $assets/$i.png" 1>&2
+
+		# @TODO a better naming is needed, perhaps @180dpi.png?
+		echo "Rendering $assets/$i@2.png"
+		$INKSCAPE --export-id="$i" \
 				  --export-dpi=180 \
 				  --export-id-only \
-				  --export-png="$ASSETS_DIR"/$i@2.png "$SRC_FILE" &> /dev/null \
-		&& $OPTIPNG -o7 --quiet "$ASSETS_DIR"/$i@2.png
+				  --export-png="$assets/$i@2.png" "$src" 1> /dev/null &&
+			$OPTIPNG -o7 --quiet "$assets/${i}@2.png" ||
+			echo "Error occurred when rendering $assets/${i}@2.png" 1>&2
 	fi
 done

--- a/src/assets-renderer/gtk3/render-assets.sh
+++ b/src/assets-renderer/gtk3/render-assets.sh
@@ -12,16 +12,16 @@ INDEX="$DIR"/assets.txt
 mkdir "$ASSETS_DIR"
 
 for i in $(cat "$INDEX")
-do 
+do
 	if [ -f "$ASSETS_DIR/$i.png" ]; then
 		echo "$ASSETS_DIR/$i.png" exists.
 	else
 		echo
 		echo Rendering "$ASSETS_DIR/$i.png"
 		$INKSCAPE --export-id=$i \
-			      --export-id-only \
-			      --export-png="$ASSETS_DIR/$i.png" "$SRC_FILE" &> /dev/null \
-		&& $OPTIPNG -o7 --quiet "$ASSETS_DIR/$i.png" 
+				  --export-id-only \
+				  --export-png="$ASSETS_DIR/$i.png" "$SRC_FILE" &> /dev/null \
+		&& $OPTIPNG -o7 --quiet "$ASSETS_DIR/$i.png"
 	fi
 	if [ -f "$ASSETS_DIR"/$i@2.png ]; then
 		echo "$ASSETS_DIR"/$i@2.png exists.
@@ -29,10 +29,9 @@ do
 		echo
 		echo Rendering "$ASSETS_DIR"/$i@2.png
 		$INKSCAPE --export-id=$i \
-			      --export-dpi=180 \
-			      --export-id-only \
-			      --export-png="$ASSETS_DIR"/$i@2.png "$SRC_FILE" &> /dev/null \
-		&& $OPTIPNG -o7 --quiet "$ASSETS_DIR"/$i@2.png 
+				  --export-dpi=180 \
+				  --export-id-only \
+				  --export-png="$ASSETS_DIR"/$i@2.png "$SRC_FILE" &> /dev/null \
+		&& $OPTIPNG -o7 --quiet "$ASSETS_DIR"/$i@2.png
 	fi
 done
-

--- a/src/assets-renderer/metacity/render-assets.sh
+++ b/src/assets-renderer/metacity/render-assets.sh
@@ -1,60 +1,37 @@
 #!/bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Required applications
 INKSCAPE=/usr/bin/inkscape
 
-SRC_FILE="$DIR"/../gtk3/assets.svg
+src="$DIR/../gtk3/assets.svg"
 
-ASSETS_DIR="$DIR"/metacity
-INDEX="$DIR"/assets.txt
+# Template variations
+templates=( "" "-dark" "-darkest" )
 
-ASSETS_DIR_DARK="$DIR"/metacity-dark
-INDEX_DARK="$DIR"/assets-dark.txt
+# The purpose of this loop is to render some assets and renaming them as necessary
+for t in "${templates[@]}"; do
+	assets="$DIR/metacity${t}"
+	index="$DIR/assets${t}.txt"
 
-ASSETS_DIR_DARKEST="$DIR"/metacity-darkest
-INDEX_DARKEST="$DIR"/assets-darkest.txt
+	# @TODO Unless the source svg files are forked, this loop can be greatly
+	# simplified if we could adjust the source svg files
+	mkdir "$assets"
+	for i in $(cat "$index"); do
+		if [ ! -f "$assets/$i.svg" ]; then
+			echo "Rendering $assets/$i.svg"
 
-mkdir "$ASSETS_DIR" "$ASSETS_DIR_DARK" "$ASSETS_DIR_DARKEST"
-
-for i in `cat "$INDEX"`
-do
-	if [ -f "$ASSETS_DIR/$i.svg" ]; then
-		echo "$ASSETS_DIR/$i.svg" exists.
-	else
-		echo
-		echo Rendering "$ASSETS_DIR/$i.svg"
-		$INKSCAPE --export-id=$i \
-				  --export-id-only \
-				  --export-plain-svg="$ASSETS_DIR/${i#titlebutton-}.svg" "$SRC_FILE" &> /dev/null
-	fi
+			if [ -z "$t" ]; then
+				name=$(echo "${i#titlebutton-}.svg")
+			else
+				name=$(echo "${i#titlebutton-}.svg" | sed "s/${t}//")
+			fi
+			$INKSCAPE --export-id="$i" \
+					  --export-id-only \
+					  --export-plain-svg="$assets/$name" "$src" 1> /dev/null ||
+				echo "Error occurred when rendering $assets/$i.png" 1>&2
+		fi
+	done
+	mv "$assets"/appmenu-backdrop.svg "$assets"/unfocused.svg
 done
-mv "$ASSETS_DIR"/appmenu-backdrop.svg "$ASSETS_DIR"/unfocused.svg
-
-for i in `cat "$INDEX_DARK"`
-do
-	if [ -f "$ASSETS_DIR_DARK/$i.svg" ]; then
-		echo "$ASSETS_DIR_DARK/$i.svg" exists.
-	else
-		echo
-		echo Rendering "$ASSETS_DIR_DARK/$i.svg"
-		$INKSCAPE --export-id=$i \
-				  --export-id-only \
-				  --export-plain-svg="$ASSETS_DIR_DARK/$(echo ${i#titlebutton-} | sed "s/-dark//").svg" "$SRC_FILE" &> /dev/null
-	fi
-done
-mv "$ASSETS_DIR_DARK"/appmenu-backdrop.svg "$ASSETS_DIR_DARK"/unfocused.svg
-
-for i in `cat "$INDEX_DARKEST"`
-do
-	if [ -f "$ASSETS_DIR_DARKEST/$i.svg" ]; then
-		echo "$ASSETS_DIR_DARKEST/$i.svg" exists.
-	else
-		echo
-		echo Rendering "$ASSETS_DIR_DARKEST/$i.svg"
-		$INKSCAPE --export-id=$i \
-				  --export-id-only \
-				  --export-plain-svg="$ASSETS_DIR_DARKEST/$(echo ${i#titlebutton-} | sed "s/-darkest//").svg" "$SRC_FILE" &> /dev/null
-	fi
-done
-mv "$ASSETS_DIR_DARKEST"/appmenu-backdrop.svg "$ASSETS_DIR_DARKEST"/unfocused.svg

--- a/src/assets-renderer/metacity/render-assets.sh
+++ b/src/assets-renderer/metacity/render-assets.sh
@@ -18,44 +18,43 @@ INDEX_DARKEST="$DIR"/assets-darkest.txt
 mkdir "$ASSETS_DIR" "$ASSETS_DIR_DARK" "$ASSETS_DIR_DARKEST"
 
 for i in `cat "$INDEX"`
-do 
+do
 	if [ -f "$ASSETS_DIR/$i.svg" ]; then
 		echo "$ASSETS_DIR/$i.svg" exists.
 	else
 		echo
 		echo Rendering "$ASSETS_DIR/$i.svg"
 		$INKSCAPE --export-id=$i \
-			      --export-id-only \
-			      --export-plain-svg="$ASSETS_DIR/${i#titlebutton-}.svg" "$SRC_FILE" &> /dev/null
+				  --export-id-only \
+				  --export-plain-svg="$ASSETS_DIR/${i#titlebutton-}.svg" "$SRC_FILE" &> /dev/null
 	fi
 done
 mv "$ASSETS_DIR"/appmenu-backdrop.svg "$ASSETS_DIR"/unfocused.svg
 
 for i in `cat "$INDEX_DARK"`
-do 
+do
 	if [ -f "$ASSETS_DIR_DARK/$i.svg" ]; then
 		echo "$ASSETS_DIR_DARK/$i.svg" exists.
 	else
 		echo
 		echo Rendering "$ASSETS_DIR_DARK/$i.svg"
 		$INKSCAPE --export-id=$i \
-			      --export-id-only \
-			      --export-plain-svg="$ASSETS_DIR_DARK/$(echo ${i#titlebutton-} | sed "s/-dark//").svg" "$SRC_FILE" &> /dev/null
+				  --export-id-only \
+				  --export-plain-svg="$ASSETS_DIR_DARK/$(echo ${i#titlebutton-} | sed "s/-dark//").svg" "$SRC_FILE" &> /dev/null
 	fi
 done
 mv "$ASSETS_DIR_DARK"/appmenu-backdrop.svg "$ASSETS_DIR_DARK"/unfocused.svg
 
 for i in `cat "$INDEX_DARKEST"`
-do 
+do
 	if [ -f "$ASSETS_DIR_DARKEST/$i.svg" ]; then
 		echo "$ASSETS_DIR_DARKEST/$i.svg" exists.
 	else
 		echo
 		echo Rendering "$ASSETS_DIR_DARKEST/$i.svg"
 		$INKSCAPE --export-id=$i \
-			      --export-id-only \
-			      --export-plain-svg="$ASSETS_DIR_DARKEST/$(echo ${i#titlebutton-} | sed "s/-darkest//").svg" "$SRC_FILE" &> /dev/null
+				  --export-id-only \
+				  --export-plain-svg="$ASSETS_DIR_DARKEST/$(echo ${i#titlebutton-} | sed "s/-darkest//").svg" "$SRC_FILE" &> /dev/null
 	fi
 done
 mv "$ASSETS_DIR_DARKEST"/appmenu-backdrop.svg "$ASSETS_DIR_DARKEST"/unfocused.svg
-

--- a/src/assets-renderer/xfwm4/render-assets.sh
+++ b/src/assets-renderer/xfwm4/render-assets.sh
@@ -1,28 +1,25 @@
 #! /bin/bash
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Required applications
 INKSCAPE=/usr/bin/inkscape
 OPTIPNG=/usr/bin/optipng
 
-INDEX="$DIR"/assets.txt
-SRC_FILES="$DIR"/assets*.svg
-
-for src_file in $SRC_FILES
-do
-	variant=$(basename ${src_file%.svg})
-	mkdir "$DIR"/$variant
-	for i in $(cat "$INDEX")
-	do
-		if [ -f "$variant/$i.png" ]; then
-			echo "$variant/$i.png" exists.
-		else
-			echo
+index="$DIR/assets.txt"
+# The loop below generates a png file for each asset element listed in $index.
+# These assets are extracted from .svg files located in $DIR
+for src in "$DIR"/assets*.svg; do
+	variant=$(basename ${src%.svg})
+	mkdir "$DIR/$variant"
+	for i in $(cat "$index"); do
+		if [ ! -f "$variant/$i.png" ]; then
 			echo Rendering "$variant/$i.png"
 			$INKSCAPE --export-id=$i \
 					  --export-id-only \
-					  --export-png="$DIR/$variant/$i.png" "$src_file" &> /dev/null \
-			&& $OPTIPNG -o7 --quiet "$DIR/$variant/$i.png"
+					  --export-png="$DIR/$variant/$i.png" "$src" 1> /dev/null &&
+				$OPTIPNG -o7 --quiet "$DIR/$variant/$i.png" ||
+				echo "Error occurred when rendering $DIR/$variant/$i.png" 1>&2
 		fi
 	done
 done

--- a/src/assets-renderer/xfwm4/render-assets.sh
+++ b/src/assets-renderer/xfwm4/render-assets.sh
@@ -22,7 +22,7 @@ do
 			$INKSCAPE --export-id=$i \
 					  --export-id-only \
 					  --export-png="$DIR/$variant/$i.png" "$src_file" &> /dev/null \
-			&& $OPTIPNG -o7 --quiet "DIR/$variant/$i.png"
+			&& $OPTIPNG -o7 --quiet "$DIR/$variant/$i.png"
 		fi
 	done
 done

--- a/src/assets-renderer/xfwm4/render-assets.sh
+++ b/src/assets-renderer/xfwm4/render-assets.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 INKSCAPE=/usr/bin/inkscape
@@ -6,7 +7,6 @@ OPTIPNG=/usr/bin/optipng
 
 INDEX="$DIR"/assets.txt
 SRC_FILES="$DIR"/assets*.svg
-
 
 for src_file in $SRC_FILES
 do
@@ -22,7 +22,7 @@ do
 			$INKSCAPE --export-id=$i \
 					  --export-id-only \
 					  --export-png="$DIR/$variant/$i.png" "$src_file" &> /dev/null \
-			&& $OPTIPNG -o7 --quiet "DIR/$variant/$i.png" 
+			&& $OPTIPNG -o7 --quiet "DIR/$variant/$i.png"
 		fi
 	done
 done


### PR DESCRIPTION
The second PR re-implements script files located in './src/assets-rendered/'. The new implementation does not alter the logic of the script files, however it:
- Allows you to catch runtime errors as necessary. For example, now you can redirect error outputs to a file instead of simply ignoring them - e.g. 'render-file.sh 2> errors.txt'.
- Reduces code complexity by eliminating unnecessary loop and if statements.
- Makes the code more readable, and improves documentation.
- Highlights key problems that need to be addressed in the future.
- Fixes a small bug existed when rendering XFWM assets - Check commit a8e68a4.