### PR TITLE
Disable magnifier border in full screen mode

### DIFF
--- a/Flat-Remix-GTK-Blue-Dark-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Dark-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Dark/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Dark/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Darker-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Darker-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Darker/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Darker/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Darkest-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Darkest-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Darkest-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Darkest-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Darkest/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Darkest/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Blue/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Blue/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Dark-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Dark-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Dark/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Dark/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Darker-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Darker-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Darker/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Darker/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Darkest-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Darkest-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Darkest-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Darkest-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Darkest/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Darkest/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Green/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Green/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Dark-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Dark-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Dark/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Dark/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Darker-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Darker-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Darker/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Darker/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Darkest-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Darkest-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Darkest-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Darkest-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Darkest/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Darkest/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Red/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Red/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Dark-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Dark-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Dark/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Dark/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Darker-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Darker-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Darker/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Darker/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Darkest-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Darkest-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Darkest-Solid-NoBorder/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Darkest-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Darkest-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Darkest/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Darkest/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow-Solid/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow-Solid/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/Flat-Remix-GTK-Yellow/cinnamon/cinnamon.css
+++ b/Flat-Remix-GTK-Yellow/cinnamon/cinnamon.css
@@ -897,7 +897,7 @@ StScrollBar {
 
 .magnifier-zoom-region {
   border: 2px solid maroon; }
-  .magnifier-zoom-region .full-screen {
+  .magnifier-zoom-region.full-screen {
     border-width: 0px; }
 
 #keyboard {

--- a/src/sass/cinnamon-sass/_common.scss
+++ b/src/sass/cinnamon-sass/_common.scss
@@ -1156,7 +1156,7 @@ StScrollBar {
 .magnifier-zoom-region {
   border: 2px solid rgba(128, 0, 0, 1);
 
-  .full-screen { border-width: 0px; }
+  &.full-screen { border-width: 0px; }
 }
 
 //


### PR DESCRIPTION
Cinnamon's Desktop Zoom will apply a .full-screen class name to the .magnifier-zoom-region element, not to a descendent of it. This was causing a red border to surround the display when in full-screen desktop zoom.

This PR removes the space that was causing the bug, so it mimics what [the default Cinnamon theme does](https://github.com/linuxmint/cinnamon/blob/f86c22c1f9094dbf934dbd31cb180b4d6587af66/data/theme/cinnamon.css#L910)

(Love the theme, by the way - have been using it for ages! Thanks for making it. Looks truly excellent.)